### PR TITLE
Add VSCode settings for the project

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "ms-vscode.PowerShell"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    // cleans up whitespace
+    "files.trimTrailingWhitespace": true,
+    // formatting style in PowerShell: https://github.com/PoshCode/PowerShellPracticeAndStyle/issues/81
+    "powershell.codeFormatting.preset": "OTBS",
+    // editor settings for formatting standards on this project
+    "editor.tabSize": 4,
+    "editor.detectIndentation": false,
+    "editor.insertSpaces": true,
+    "editor.formatOnSave": true,
+    // editor settings that will auto add the closing quote or curly brace
+    "editor.autoClosingBrackets": "always",
+    "editor.autoClosingQuotes": "always",
+    "editor.autoSurround": "languageDefined"
+}


### PR DESCRIPTION
Adding two files.

extensions.json -> recommends the powershell plugin (if it is not installed already. This may be helpful if we have any OnRamp members join us.)
settings.json -> removes trailing white space, sets the formatting to OBTS, adds closing brackets, quotes.

Picked OBTS as a style based on this discussion and it's popularity, but willing to change if there is a desire for something different. -> https://github.com/PoshCode/PowerShellPracticeAndStyle/issues/81